### PR TITLE
Issue #29 Suggestion to reserve -ref suffix for the names of elements which contain a REST url reference to a LCF entity enhancement

### DIFF
--- a/lcf-schema/src/main/resources/lcf-v1.0-entities.xsd
+++ b/lcf-schema/src/main/resources/lcf-v1.0-entities.xsd
@@ -237,7 +237,7 @@
 			<xs:element ref="amount"/>
 			<xs:element ref="currency" minOccurs="0"/>
 			<xs:element ref="payment-status" minOccurs="0"/>
-			<xs:element ref="transaction-ref" minOccurs="0"/>
+			<xs:element ref="transaction-reference" minOccurs="0"/>
 			<xs:element ref="note" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:group>
@@ -540,7 +540,7 @@
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
-	<xs:element name="transaction-ref" type="nonEmptyString"/>
+	<xs:element name="transaction-reference" type="nonEmptyString"/>
 	<xs:element name="type-name" type="nonEmptyString"/>
 	<xs:element name="unavailable-hold-items" type="xs:int"/>
 	<xs:element name="unnamed-contributor" type="unnamedContributorType"/>

--- a/lcf-schema/src/main/resources/lcf-v1.0-entities.xsd
+++ b/lcf-schema/src/main/resources/lcf-v1.0-entities.xsd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2016 rel. 2 sp1 (x64) (http://www.altova.com) by Matthew J. Dovey (Ceridwen.com) -->
 <!-- edited with XMLSPY v5 U (http://www.xmlspy.com) by XMLSPY 5 Enterprise Ed. (Talis Information Ltd) -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
 	<xs:element name="charge">
@@ -467,7 +468,7 @@
 	<xs:element name="on-loan-items" type="xs:int"/>
 	<xs:element name="on-loan-ref" type="nonEmptyString"/>
 	<xs:element name="other-description" type="nonEmptyString"/>
-	<xs:element name="other-manifestation-in-series-id" type="nonEmptyString"/>
+	<xs:element name="other-manifestation-in-series-ref" type="nonEmptyString"/>
 	<xs:element name="overdue-items" type="xs:int"/>
 	<xs:element name="overdue-items-limit" type="xs:int"/>
 	<xs:element name="owner" type="nonEmptyString"/>
@@ -503,7 +504,7 @@
 			<xs:sequence>
 				<xs:element ref="title" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element ref="volume-or-part" minOccurs="0"/>
-				<xs:element ref="other-manifestation-in-series-id" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="other-manifestation-in-series-ref" minOccurs="0" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>

--- a/lcf-schema/src/main/resources/lcf-v1.0-entities.xsd
+++ b/lcf-schema/src/main/resources/lcf-v1.0-entities.xsd
@@ -169,7 +169,7 @@
 			<xs:element ref="loan-restriction" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="loan-fee" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="patrons-in-hold-queue" minOccurs="0"/>
-			<xs:element ref="manifestation-record-ref" minOccurs="0"/>
+			<xs:element ref="manifestation-record" minOccurs="0"/>
 			<xs:element ref="manifestation-status"/>
 			<xs:element ref="items-in-stock" minOccurs="0"/>
 			<xs:element ref="item-ref" minOccurs="0" maxOccurs="unbounded"/>
@@ -436,7 +436,7 @@
 	<xs:element name="location-ref" type="nonEmptyString"/>
 	<xs:element name="locator" type="nonEmptyString"/>
 	<xs:element name="manifestation-id-type" type="manifestationIDType"/>
-	<xs:element name="manifestation-record-ref" type="nonEmptyString"/>
+	<xs:element name="manifestation-record" type="nonEmptyString"/>
 	<xs:element name="manifestation-ref" type="nonEmptyString"/>
 	<xs:element name="manifestation-status" type="manifestationStatus"/>
 	<xs:element name="media-type">


### PR DESCRIPTION
As per issue #29 

* Updated E01D06.3 to be -ref rather than -id
* Changed entity E01D16 from manifestation-record-ref to manifestation-record 
* Changed entity E08D10 from transaction-ref to transaction-reference